### PR TITLE
Fix mongoose and promise warings for npm test

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,12 @@ var Socket = require('socket.io');
 
 var util = require('./libs/util');
 
-mongoose.connect(config.DBHost);
+var options = {
+  useMongoClient: true
+};
+
+mongoose.Promise = global.Promise;
+mongoose.connect(config.DBHost, options);
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 


### PR DESCRIPTION
Two DeprecationWarnings caused by npm test were fixed.
- open() is deprecated in mongoose >= 4.11.0, use openUri() instead, or set the useMongoClient option if using connect() or createConnection()
- mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead

Signed-off-by: KwangHyuk Kim <hyuki.kim@samsung.com>