### PR TITLE
Fix WATT url strings on about menu

### DIFF
--- a/libs/brackets-server/embedded-ext/about/nls/ko/strings.js
+++ b/libs/brackets-server/embedded-ext/about/nls/ko/strings.js
@@ -11,7 +11,7 @@ define({
     "ABOUT_TEXT_LINE1"             : "릴리즈 {VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH} {BUILD_TYPE}",
     "ABOUT_TEXT_BUILD_TIMESTAMP"   : "빌드 시각: ",
     "ABOUT_TEXT_LINE2"             : "제3자 소프트웨어의 사용에 관한 공지, 이용 약관은 업데이트 예정입니다.",
-    "ABOUT_TEXT_LINE3"             : "문서와 소스 코드는 <a href='{WATT_URL}'>{WATT_URL}</a>에서 구할 수 있습니다.",
+    "ABOUT_TEXT_LINE3"             : "문서와 소스 코드는 <a href='{WATT_URL1}'>{WATT_URL1}</a>에서 구할 수 있습니다.",
     "ABOUT_TEXT_WEB_PLATFORM_DOCS" : "웹 플랫폼 문서와 웹 플랫폼 로고는 크리에이티브 커먼즈 저작자표시 라이선스, <a href='{WEB_PLATFORM_DOCS_LICENSE}'>CC-BY 3.0 Unported</a> 로 배포됩니다.",
     "DEVELOPMENT_BUILD"            : "개발 빌드"
 });


### PR DESCRIPTION
For the korean version of about dialog menu, proper url strings are updated for WATT.

Signed-off-by: KwangHyuk Kim <hyuki.kim@samsung.com>