### PR TITLE
Optional testing mechanism is needed for several reasons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,22 @@
 MOCHA := "mocha"
 NYC := "nyc"
 
-TESTS = test/*.js
-TESTS_WITH_TIZEN = test/*.js libs/brackets-server/embedded-ext/project/test/*.js
+define test_node
+	$(NYC) --reporter=text --reporter=html $(MOCHA) --timeout=$(1)
+endef
 
+TESTS = test/*.js
+TESTS_TIZEN = libs/brackets-server/embedded-ext/project/test/*.js
 
 test:
 	@if ! type "tizen" > /dev/null; then make test-default; else make test-extension; fi
 
-
 test-default:
 	@echo "Run default test"
-	@$(NYC) --reporter=text --reporter=html $(MOCHA) --timeout=10000 $(TESTS)
+	$(call test_node,10000) $(TESTS)
 
 test-extension:
 	@echo "Run test with tizen extension features"
-	@$(NYC) --reporter=text --reporter=html $(MOCHA) --timeout=10000 $(TESTS) $(TESTS_WITH_TIZEN)
+	$(call test_node,10000) $(TESTS) $(TESTS_TIZEN)
 
 .PHONY: test test-default test-extension

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+MOCHA := "mocha"
+NYC := "nyc"
+
+TESTS = test/*.js
+TESTS_WITH_TIZEN = test/*.js libs/brackets-server/embedded-ext/project/test/*.js
+
+
+test:
+	@if ! type "tizen" > /dev/null; then make test-default; else make test-extension; fi
+
+
+test-default:
+	@echo "Run default test"
+	@$(NYC) --reporter=text --reporter=html $(MOCHA) --timeout=10000 $(TESTS)
+
+test-extension:
+	@echo "Run test with tizen extension features"
+	@$(NYC) --reporter=text --reporter=html $(MOCHA) --timeout=10000 $(TESTS) $(TESTS_WITH_TIZEN)
+
+.PHONY: test test-default test-extension

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./app.js",
-    "test": "nyc --reporter=text --reporter=html mocha --timeout=10000 ./test ./libs/brackets-server/embedded-ext/project/test"
+    "test": "make test"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
  : run test on CI server with defined set of tests
  : run test based on capabilities (optional features such as Tizen wgt packaging)

Introduce test Makefile for selective testing.
Makefile checks for optional feature (tizen) and run proper test script.

Signed-off-by: Andy Cho <sung.h.cho@samsung.com>