### PR TITLE
Fix build error for grunt build on brackets_server

### DIFF
--- a/libs/brackets-server/Gruntfile.js
+++ b/libs/brackets-server/Gruntfile.js
@@ -117,25 +117,28 @@ function addEmbeddedExtesions(config) {
         rj = config.requirejs;
 
     dirs.forEach(function (file) {
-        var mod = {
-            options: {
-                name: "main",
-                out: "brackets-dist/extensions/default/" + file + "/main.js",
-                baseUrl: "embedded-ext/" + file + "/",
-                preserveLicenseComments: false,
-                optimize: "uglify2",
-                uglify2: {},
-                paths: {
-                    "text" : "../../brackets-src/src/thirdparty/text/text",
-                    "i18n" : "../../brackets-src/src/thirdparty/i18n/i18n",
-                },
-                generateSourceMaps: true,
-                useSourceUrl: true,
-                wrap: false
-            }
-        };
+        var stat = fs.statSync(root + "/" + file);
+        if(stat.isDirectory()) {
+            var mod = {
+                options: {
+                    name: "main",
+                    out: "brackets-dist/extensions/default/" + file + "/main.js",
+                    baseUrl: "embedded-ext/" + file + "/",
+                    preserveLicenseComments: false,
+                    optimize: "uglify2",
+                    uglify2: {},
+                    paths: {
+                        "text" : "../../brackets-src/src/thirdparty/text/text",
+                        "i18n" : "../../brackets-src/src/thirdparty/i18n/i18n",
+                    },
+                    generateSourceMaps: true,
+                    useSourceUrl: true,
+                    wrap: false
+                }
+            };
 
-        rj[file] = mod;
+            rj[file] = mod;
+        }
     });
 }
 


### PR DESCRIPTION
Add implementation to check whether detected file item is directory on the addEmbeddedExtesions() function.
Hence only directory will be added as an embedded extension.

Signed-off-by: KwangHyuk Kim <hyuki.kim@samsung.com>