### PR TITLE
Fix help.out not found issue

### DIFF
--- a/libs/brackets-server/embedded-ext/about/main.js
+++ b/libs/brackets-server/embedded-ext/about/main.js
@@ -33,6 +33,6 @@ define(function (require, exports, module) {
         // Then create a menu item bound to the command
         // The label of the menu item is the name we gave the command (see above)
         var menu = Menus.getMenu(Menus.AppMenuBar.HELP_MENU);
-        menu.addMenuItem(HELP_ABOUT_WATT, undefined, Menus.BEFORE, Commands.HELP_ABOUT);
+        menu.addMenuItem(HELP_ABOUT_WATT);
     });
 });


### PR DESCRIPTION
Commands.HELP_ABOUT menu is not existed so it makes some error when
launching the brackets. To fix error, add the menu item directly.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>