### PR TITLE
Fix the define of 'into folder'

### DIFF
--- a/libs/brackets-server/embedded-ext/importfile/nls/ko/strings.js
+++ b/libs/brackets-server/embedded-ext/importfile/nls/ko/strings.js
@@ -16,6 +16,6 @@ define({
     "IMPORT_FILE_MENU_TITLE"            : "파일 삽입",
     "IMPORT_SHARED_FILE_LABEL"          : "공유 프로젝트 선택 :",
     "IMPORT_SHARED_FILE_MENU_TITLE"     : "공유 파일 삽입",
-    "INTO_FOLDER_lABEL"                 : "저장 폴더 :",
+    "INTO_FOLDER_LABEL"                 : "저장 폴더 :",
     "PASTE_FILE"                        : "붙여넣기"
 });

--- a/libs/brackets-server/embedded-ext/importfile/nls/root/strings.js
+++ b/libs/brackets-server/embedded-ext/importfile/nls/root/strings.js
@@ -16,6 +16,6 @@ define({
     "IMPORT_FILE_MENU_TITLE"            : "Import File",
     "IMPORT_SHARED_FILE_LABEL"          : "Select Shared Project :",
     "IMPORT_SHARED_FILE_MENU_TITLE"     : "Import Shared File",
-    "INTO_FOLDER_lABEL"                 : "Into Folder :",
+    "INTO_FOLDER_LABEL"                 : "Into Folder :",
     "PASTE_FILE"                        : "Paste"
 });


### PR DESCRIPTION
'into folder' is named as INTO_FOLDER_lABEL.
It needs to be fixed to INTO_FOLDER_LABEL for 2 reasons :
  - All other characters are in capital except 'l'.
  - In [1], it is used as INTO_FOLDER_LABEL.

[1] libs/brackets-server/embedded-ext/importfile/htmlContent/Import-File.html

Signed-off-by: hyunduk.kim <hyunduk.kim@samsung.com>