### PR TITLE
Add implementation to support unit test on travis-ci

### DIFF
--- a/launch
+++ b/launch
@@ -404,6 +404,16 @@ Please ensure to execute tizen command if use WGT packaging.''')
     % (pkg_manager, pkg_manager), shell=True)
   return os.path.dirname(tizen_path)
 
+def build_brackets():
+  Log.info('Build brackets if necessary.')
+  try:
+    subprocess.check_call('cd libs/brackets-server/brackets-dist 2>/dev/null' \
+      '|| { cd libs/brackets-server; grunt build; }', shell=True)
+  except:
+    Log.err('Fail to build. Please try rerun after fix build break.')
+    return False
+  return True
+
 def run_service(verbose):
   print_msg = True
   need_rebuild = False
@@ -411,14 +421,6 @@ def run_service(verbose):
   srv_cmd = ['node', 'app.js']
   rlist = [sys.stdin]
   devnull = open(os.devnull, 'w')
-
-  Log.info('Build if necessary.')
-  try:
-    subprocess.check_call('cd libs/brackets-server/brackets-dist 2>/dev/null' \
-      '|| { cd libs/brackets-server; grunt build; }', shell=True)
-  except:
-    Log.err('Fail to build. Please try rerun after fix build break.')
-    return 1
 
   if verbose:
     out = None
@@ -524,6 +526,9 @@ def main():
 
   ret, grunt_path = prepare_nodejs(args.npm)
   if not ret:
+    return 1
+
+  if not build_brackets():
     return 1
 
   if not check_mongodb():

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "grunt-html": "^8.4.0",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.2.0",
+    "node-mocks-http": "^0.0.6",
     "nyc": "^11.0.2",
     "shared-git-hooks": "^1.2.1",
     "tmp": "^0.0.31"

--- a/routes/brackets.js
+++ b/routes/brackets.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const config = require('config');
 const debug = require('debug')('routes:brackets');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
+const httpMock = require('node-mocks-http');
 const path = require('path');
 const urlUtil = require('url');
 
@@ -23,6 +25,9 @@ module.exports = function(express, server, wsServer) {
       const reqUrl = decodeURIComponent(url.substr('/proxy/'.length));
       let options = urlUtil.parse(reqUrl);
       const httpClient  = options.protocol === 'http' ? http : https;
+      if (config.util.getEnv('NODE_ENV') === 'test') {
+        httpClient = httpMock;
+      } 
 
       delete options.protocol;
       options.method = 'GET';


### PR DESCRIPTION
- add grunt build for brackets-server when launch is working as dry-run mode
  : some tests wants to scratch build of brackets-server
- add mock http for a test case that is using node module of http
  : travis does not support local http server connection by itself

Signed-off-by: KwangHyuk Kim <hyuki.kim@samsung.com>