### PR TITLE
Fix 'pip install' error on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
   - "6"
 
 before_install:
-  - pip install psutil
-  - pip install requests
+  - pip install psutil --user travis
+  - pip install requests --user travis
 
 matrix:
   include:


### PR DESCRIPTION
Permission denined error occurred when installing the pip packages.
To fix error, add user option to the pip install.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>