### PR TITLE
Fix file import issue

### DIFF
--- a/libs/brackets-server/embedded-ext/dndfile/main.js
+++ b/libs/brackets-server/embedded-ext/dndfile/main.js
@@ -21,9 +21,8 @@ define(function (require, exports, module) {
             if (event.target.readyState === window.FileReader.DONE) {
                 var filePath = directoryPath + file.name;
                 var generatedFile = FileSystem.getFileForPath(filePath);
-                generatedFile.write(event.target.result,function(){
-                    // Not implemented yet.
-                });
+                generatedFile.write(event.target.result);
+                ProjectManager.refreshFileTree();
             }
         };
     }
@@ -32,8 +31,7 @@ define(function (require, exports, module) {
         return function(file) {
             var reader = new window.FileReader();
             reader.onloadend = fileOnLoaded(file, directoryPath);
-            reader.readAsText(file);
-            // reader.readAsBinaryString(file);
+            reader.readAsArrayBuffer(file);
         };
     }
 

--- a/libs/brackets-server/embedded-ext/file-extension/main.js
+++ b/libs/brackets-server/embedded-ext/file-extension/main.js
@@ -118,6 +118,7 @@ define(function (require, exports, module) {
                                 var filePath = baseDirEntry + file.name;
                                 var newFile = FileSystem.getFileForPath(filePath);
                                 newFile.write(event.target.result);
+                                ProjectManager.refreshFileTree();
                             }
                         };
                     };
@@ -129,7 +130,7 @@ define(function (require, exports, module) {
 
                         // Closure to capture the file information
                         reader.onloadend = loaded(file);
-                        reader.readAsBinaryString(file);
+                        reader.readAsArrayBuffer(file);
                     }
                 }
             });


### PR DESCRIPTION
Some files are broken when importing files on WATT.
To fix it, read file as array buffer and refresh file
after importing files.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>