### PR TITLE
Enable 'sort-vars' option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,14 +45,15 @@
         "new-parens": 2,
         "no-new-object": 2,
         "no-invalid-this": 0,
-        indent: [1, 2],
+        "indent": [1, 2],
 
         "valid-jsdoc": 0,
         "valid-typeof": 2,
 
         "no-trailing-spaces": 0,
         "eol-last": 0,
-        "quotes": ["error", "single", { "avoidEscape": true }]
+        "quotes": ["error", "single", { "avoidEscape": true }],
+        "sort-vars": [1, { "ignoreCase": true }]
     },
     "parserOptions": {
       "ecmaVersion": 6

--- a/libs/brackets-server/.eslintrc
+++ b/libs/brackets-server/.eslintrc
@@ -43,14 +43,15 @@
         "new-parens": 2,
         "no-new-object": 2,
         "no-invalid-this": 0,
-        indent: [1, 4],
+        "indent": [1, 4],
 
         "valid-jsdoc": 0,
         "valid-typeof": 2,
 
         "no-trailing-spaces": 0,
         "eol-last": 0,
-        "quotes": ["error", "double", { "avoidEscape": true }]
+        "quotes": ["error", "double", { "avoidEscape": true }],
+        "sort-vars": [1, { "ignoreCase": true }]
     },
     "parserOptions": {
       "ecmaVersion": 6


### PR DESCRIPTION
Add 'sort-vars' option to check whether the variable
names are sorted alphabetically or not.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>