### PR TITLE
Implement wasm-debug extension

### DIFF
--- a/launch
+++ b/launch
@@ -351,6 +351,46 @@ def get_emscripten_path(version):
     return ''
   return emscripten_path
 
+def build_wabt():
+  Log.info('Build wabt if necessary.')
+  try:
+    subprocess.check_call('cd tools/wabt; make gcc-release-no-tests', shell=True)
+  except:
+    Log.err('Fail to build wabt. Please try rerun after fix build break.')
+    return False
+  return True
+
+def ensure_wabt(wabt_path):
+  wabt_bin_path = os.path.join(wabt_path, 'bin')
+  if os.path.isdir(wabt_bin_path): return True
+
+  Log.warn('Download wabt tool')
+  url = 'https://github.com/WebAssembly/wabt/archive/'
+  file_name = '1.0.0.tar.gz'
+  dest_path = os.path.join(tool_path, file_name)
+  if not download_file(url + file_name, dest_path): return False
+
+  tar = tarfile.open(dest_path)
+  tar.extractall(tool_path)
+  tar.close()
+  os.remove(dest_path)
+  portable_path = os.path.join(tool_path, 'wabt-1.0.0')
+  os.rename(portable_path, wabt_path)
+
+  return build_wabt()
+
+def get_wabt_path():
+  Log.info('Check wabt')
+  wabt_path = os.path.join(tool_path, 'wabt')
+  wabt_bin_path = os.path.join(wabt_path, 'bin')
+  if os.path.isdir(wabt_bin_path): return wabt_bin_path
+
+  if not ensure_wabt(wabt_path):
+    Log.err('Fail to install wabt. Please install wabt manually.(https://github.com/WebAssembly/wabt)')
+    return ''
+
+  return wabt_bin_path
+
 def ensure_nacl(nacl_path):
   bin_path = os.path.join(nacl_path, 'naclsdk')
   if os.path.isfile(bin_path): return True
@@ -546,7 +586,10 @@ def main():
     if emscripten_path == '': return 1
 
   Log.info('Use emscripten at %s' % emscripten_path)
-  pathlist = [grunt_path, emscripten_path, os.path.join(tool_path, 'WebIDLBinder'), '']
+
+  wabt_bin_path = get_wabt_path()
+
+  pathlist = [grunt_path, emscripten_path, os.path.join(tool_path, 'WebIDLBinder'), wabt_bin_path, '']
   tizen_path = get_tizen_path()
   if tizen_path != '':
     pathlist.insert(-1, tizen_path)

--- a/libs/brackets-server/Gruntfile.js
+++ b/libs/brackets-server/Gruntfile.js
@@ -330,7 +330,8 @@ module.exports = function (grunt) {
                           "project/node/**",
                           "file-extension/node/**",
                           "tizen-profile/node/**",
-                          "pwe/node/**"
+                          "pwe/node/**",
+                          "wasm-debug/node/**"
                         ]
                     },
                     /* styles, fonts and images */

--- a/libs/brackets-server/embedded-ext/file-extension/main.js
+++ b/libs/brackets-server/embedded-ext/file-extension/main.js
@@ -248,13 +248,6 @@ define(function (require, exports, module) {
         operation = "CUT";
     }
 
-    // Remove unnecessary prefix path
-    function convertRelativePath(path) {
-        var newPath = path.split("/");
-        newPath.splice(0, 2);
-        return newPath.join("/");
-    }
-
     function handlePasteFile() {
         selected = ProjectManager.getSelectedItem();
         if (selected) {
@@ -276,8 +269,9 @@ define(function (require, exports, module) {
                 }
 
                 const projectId = PreferencesManager.getViewState("projectId");
-                const sourcePath = convertRelativePath(entry.parentPath);
-                const destPath = convertRelativePath(selectedPath);
+
+                const sourcePath = brackets.app.convertRelativePath(entry.parentPath);
+                const destPath = brackets.app.convertRelativePath(selectedPath);
 
                 _nodeDomain.exec(operation, projectId, sourcePath, entry.name, destPath)
                     .done(() => {

--- a/libs/brackets-server/embedded-ext/wasm-debug/main.js
+++ b/libs/brackets-server/embedded-ext/wasm-debug/main.js
@@ -1,0 +1,58 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    // Brackets modules
+    const Commands               = brackets.getModule("command/Commands"),
+        CommandManager           = brackets.getModule("command/CommandManager"),
+        DefaultDialogs           = brackets.getModule("widgets/DefaultDialogs"),
+        Dialogs                  = brackets.getModule("widgets/Dialogs"),
+        ExtensionUtils           = brackets.getModule("utils/ExtensionUtils"),
+        FileUtils                = brackets.getModule("file/FileUtils"),
+        Menus                    = brackets.getModule("command/Menus"),
+        NodeDomain               = brackets.getModule("utils/NodeDomain"),
+        PreferencesManager       = brackets.getModule("preferences/PreferencesManager"),
+        ProjectManager           = brackets.getModule("project/ProjectManager");
+
+    const _domainPath = ExtensionUtils.getModulePath(module, "node/DebugDomain"),
+        _nodeDomain = new NodeDomain("debugDomain", _domainPath);
+
+    const ExtensionStrings = require("strings");
+
+    const DEBUG_WASM2WAST = "debug.wasm2wast";
+
+    function showErrorDialog(message) {
+        Dialogs.showModalDialog(
+            DefaultDialogs.DIALOG_ID_ERROR,
+            "Error",
+            message
+        );
+    }
+
+    function handleWasm2Wast() {
+        const item = ProjectManager.getSelectedItem();
+        if (!item) {
+            showErrorDialog(ExtensionStrings.ERROR_FILE_NOT_FOUND);
+            return;
+        }
+
+        if (FileUtils.getFileExtension(item.fullPath) !== "wasm") {
+            showErrorDialog(ExtensionStrings.ERROR_NOT_WASM_FILE);
+            return;
+        }
+
+        const projectId = PreferencesManager.getViewState("projectId");
+        _nodeDomain.exec("wasm2wast", projectId, brackets.app.convertRelativePath(item.fullPath)).done(() => {
+            ProjectManager.refreshFileTree();
+        }).fail((err) => {
+            showErrorDialog(ExtensionStrings.ERROR_TRANSLATE_WASM);
+            console.log(err);
+        });
+    }
+
+    CommandManager.register("wasm -> wast", DEBUG_WASM2WAST, handleWasm2Wast);
+
+    const menu = Menus.getMenu("debug-menu");
+
+    menu.addMenuDivider();
+    menu.addMenuItem(DEBUG_WASM2WAST);
+});

--- a/libs/brackets-server/embedded-ext/wasm-debug/nls/ko/strings.js
+++ b/libs/brackets-server/embedded-ext/wasm-debug/nls/ko/strings.js
@@ -1,0 +1,6 @@
+// Korean - ko strings
+define({
+    "ERROR_TRANSLATE_WASM"    : "WASM을 변환하는데 실패했습니다!",
+    "ERROR_FILE_NOT_FOUND"    : "선택된 파일이 없습니다.",
+    "ERROR_NOT_WASM_FILE"     : "선택된 파일이 WASM 형식이 아닙니다."
+});

--- a/libs/brackets-server/embedded-ext/wasm-debug/nls/root/strings.js
+++ b/libs/brackets-server/embedded-ext/wasm-debug/nls/root/strings.js
@@ -1,0 +1,6 @@
+// English - root strings
+define({
+    "ERROR_TRANSLATE_WASM"    : "Failed to translate wasm!",
+    "ERROR_FILE_NOT_FOUND"    : "Selected file not found",
+    "ERROR_NOT_WASM_FILE"     : "Selected file isn't wasm file"
+});

--- a/libs/brackets-server/embedded-ext/wasm-debug/nls/strings.js
+++ b/libs/brackets-server/embedded-ext/wasm-debug/nls/strings.js
@@ -1,0 +1,16 @@
+define(function (require, exports, module) {
+
+    "use strict";
+
+    // Code that needs to display user strings should call require("strings") to load
+    // strings.js. This file will dynamically load strings.js for the specified by bracketes.locale.
+    //
+    // Translations for other locales should be placed in nls/<locale<optional country code>>/strings.js
+    // Localization is provided via the i18n plugin.
+    // All other bundles for languages need to add a prefix to the exports below so i18n can find them.
+    // TODO: dynamically populate the local prefix list below?
+    module.exports = {
+        root: true,
+        ko: true
+    };
+});

--- a/libs/brackets-server/embedded-ext/wasm-debug/node/DebugDomain.js
+++ b/libs/brackets-server/embedded-ext/wasm-debug/node/DebugDomain.js
@@ -1,0 +1,53 @@
+(function () {
+    "use strict";
+
+    const exec = require("child_process").exec,
+        path = require("path");
+
+    const DEBUG_DOMAIN = "debugDomain";
+
+    let _domainManager;
+
+    function init(domainManager) {
+        _domainManager = domainManager;
+        if (!_domainManager.hasDomain(DEBUG_DOMAIN)) {
+            _domainManager.registerDomain(DEBUG_DOMAIN, {major: 0, minor: 1});
+        }
+
+        function handleWasm2Wast(projectId, src, callback) {
+            const sourcePath = path.join(process.cwd(), "projects", projectId);
+            const source = path.join(sourcePath, src);
+            const output = path.join(path.dirname(source), path.basename(src, ".wasm") + ".wast");
+
+            const wabtPath = path.join(process.cwd(), "tools", "wabt");
+            const wasm2wastBin = path.join(wabtPath, "bin", "wasm2wast");
+
+            const command = wasm2wastBin + " " + source + " -o " + output;
+
+            let child = exec(command, { cwd: sourcePath });
+
+            child.on("exit", () => {
+                callback(null);
+            });
+
+            child.on("error", (err) => {
+                callback(err);
+            });
+        }
+
+        _domainManager.registerCommand(
+            DEBUG_DOMAIN,
+            "wasm2wast",
+            handleWasm2Wast,
+            true,
+            "Translate wasm to wast",
+            [
+                {name: "projectId", type: "string"},
+                {name: "src", type: "string"}
+            ],
+            []
+        );
+    }
+
+    exports.init = init;
+}());

--- a/libs/brackets-server/embedded-ext/wasm-debug/strings.js
+++ b/libs/brackets-server/embedded-ext/wasm-debug/strings.js
@@ -1,0 +1,5 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    module.exports = require("i18n!nls/strings");
+});

--- a/libs/brackets-server/hacks/app.js
+++ b/libs/brackets-server/hacks/app.js
@@ -84,4 +84,17 @@ define(function (require, exports) {
 
         return serverPath.join("/");
     };
+
+    /**
+     *
+     * Remove unnecessary path data from file path
+     *
+     * @param {string} filePath
+     * @return {string} Converted file path
+     */
+    exports.convertRelativePath = function (path) {
+        var newPath = path.split("/");
+        newPath.splice(0, 2);
+        return newPath.join("/");
+    };
 });


### PR DESCRIPTION
- Add 'wabt' tool to analyze wasm file
- Add 'wasm -> wast' menu to translate file from wasm to wast
- Move 'convertRelativePath' function to the brackets util

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>