### PR TITLE
Fix travis build on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       dist: trusty
       sudo: enabled
     - os: osx
+      # FIXME: Use xcode7.3 until fix the "pip not found" issue
+      osx_image: xcode7.3
 
 install:
   - ./launch -d


### PR DESCRIPTION
We are getting "Pip command not found" during travis build
on OSX. We need to add pip setup to the launch script. I
fixed the issue temporarily using the xcode 7.3 image until
I fixed issue.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>