### PR TITLE
Fix a problem where failing to install pip

### DIFF
--- a/launch
+++ b/launch
@@ -77,7 +77,11 @@ def install_pip():
   return True
 
 def import_additional():
-  status = subprocess.call('which pip > /dev/null', shell=True)
+  if os_name == OS_DARWIN:
+    status = subprocess.call('which pip2 > /dev/null', shell=True)
+  else:
+    status = subprocess.call('which pip > /dev/null', shell=True)
+    
   if status != 0 and not install_pip():
     Log.err('Fail to install pip')
     sys.exit(1)


### PR DESCRIPTION
Change the execution of pip to the pip2 when the OS is OSX.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>
  