### PR TITLE
Apply the latest version of admin-lte module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">6.9.5"
   },
   "dependencies": {
-    "admin-lte": "^2.3.11",
+    "admin-lte": "^2.4.2",
     "async": "^2.3.0",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "~1.16.0",

--- a/views/project.ejs
+++ b/views/project.ejs
@@ -110,7 +110,7 @@
 <!-- Bootstrap -->
 <script src="/components/bootstrap/js/bootstrap.min.js"></script>
 <!-- AdminLTE App -->
-<script src="/components/AdminLTE/js/app.min.js"></script>
+<script src="/components/AdminLTE/js/adminlte.min.js"></script>
 
 <script>
   var projects = <%- JSON.stringify(projects) %>;


### PR DESCRIPTION
- version 2.3.11 -> 2.4.2
- From package.json, dependency of admin-lte is specified to be compatable with 2.3.11.
  Therefore, npm just installed 2.4.2. but, app.js is just replaced with adminlte.min.js on 2.4.2.
  In order to fix load failure of app.min.js for admin-lte, the version of admin-lte is now modified
  and related code is also modified.

Signed-off-by: KwangHyuk Kim <hyuki.kim@samsung.com>