### PR TITLE
Fix temp directory cleanup problem for .wgt packaging test

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
         "mocha": true,
         "browser": true
     },
+    "parser": "babel-eslint",
     "rules": {
         "no-bitwise": 0,
         "curly": 2,
@@ -57,7 +58,7 @@
         "sort-vars": [2, { "ignoreCase": true }]
     },
     "parserOptions": {
-      "ecmaVersion": 6
+      "ecmaVersion": 2017
     },
     "globals": {
         "brackets": false,

--- a/libs/brackets-server/embedded-ext/project/test/test.js
+++ b/libs/brackets-server/embedded-ext/project/test/test.js
@@ -66,6 +66,15 @@ function prepareMakefile(makefileContents) {
     });
 }
 
+const cleanupDirFunc = function(cleanupFun, path) {
+    return new Promise(resolve => {
+        cleanupFun(function() {
+            resolve("deleted");
+        });
+    });
+};
+
+
 describe("'project' extension", () => {
     describe(".wgt packaging", () => {
         it("should be able to check packaging availability", (done) => {
@@ -76,18 +85,15 @@ describe("'project' extension", () => {
         });
 
         //getTempDir test
-        //TODO: change to async - await approach after node upgrade to 7.6 or later
-        it("should be able to check geting temporary directory", () => {
-            const tempPromise = project.getTempDir();
-            expect(tempPromise).to.be.a("promise");
-            return tempPromise.then ( (result) => {
-                expect(result.tmpDirPath).to.be.a("string").that.is.not.empty;
-                expect(fs.existsSync(result.tmpDirPath)).to.be.true;
-                expect(result.tmpDirCleanup).to.be.a("function");
-                //cleanup
-                result.tmpDirCleanup();
-                expect(fs.existsSync(result.tmpDirPath)).to.be.false;
-            });
+        it("should be able to check geting temporary directory", async () => {
+            const result = await project.getTempDir();
+            expect(result.tmpDirPath).to.be.a("string").that.is.not.empty;
+            expect(fs.existsSync(result.tmpDirPath)).to.be.true;
+            expect(result.tmpDirCleanup).to.be.a("function");
+            const resultCleanup = await cleanupDirFunc(result.tmpDirCleanup);
+            expect(resultCleanup).to.be.a("string");
+            expect(resultCleanup).to.equal("deleted");
+            expect(fs.existsSync(result.tmpDirPath)).to.be.false;
         });
 
         //patchIndexFile test

--- a/package.json
+++ b/package.json
@@ -52,12 +52,13 @@
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
     "grunt-contrib-csslint": "^2.0.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-eslint": "^20.0.0",
+    "grunt-eslint": "^21.0.0",
     "grunt-gitnewer": "^1.0.5",
     "grunt-html": "^8.4.0",
     "load-grunt-tasks": "^3.5.2",


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TIZENWF-2495
[Problem] npm test fails with one failing test
[Cause] cleanupCallback is asynchronous in result of [1] This causes failure of check being right after callback:

    result.tmpDirCleanup(); expect(fs.existsSync(result.tmpDirPath)).to.be.false;

[Solution] Convert test to asynchronous one
[Remarks] New testing code uses async await. In order to pass eslint check eslint configuration changes needed to be done according to [2]

    [1] https://github.com/raszi/node-tmp/issues/57
    [2] http://quabr.com/43933907/eslint-parsing-error-parsing-error-unexpected-token

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>