### PR TITLE
Move invoking launch script when container starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,9 +83,10 @@ EXPOSE 3000
 ENV NODE_ENV=docker
 
 # Prepare WATT (download node modules, emsdk, build DE ).
-RUN ./launch --dry && \
-     npm cache clean --force && \
-     rm -rf tools/wabt/out/
+# This affects docker image size, can be used to speed up container start.
+# RUN ./launch --dry
+#     npm cache clean --force && \
+#     rm -rf tools/wabt/out/
 
 # Launch WATT by CMD command so you can replace it by any command to test image.
 # Features behind flags like pwe, smart things are not added.


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TIZENWF-2493
[Problem] Docker images is huge.
[Solution] Do not invoke launch script while building docker images.
           This means that launch script will be called once container
           starts. This approximately takes two hours. This might be
           issue once container for some reason needs to be restarted
           resulting in no WATT availability during container setup.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>