### PR TITLE
Add possibility to open WATT samples as anonymous user

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,6 +87,7 @@ app.use('/project', require('./routes/project')(express));
 app.use('/update', require('./routes/update')(express));
 app.use('/brackets', require('./routes/brackets')(express, server, wsServer));
 app.use('/brackets-ext', require('./routes/brackets-ext')(express));
+app.use('/demos', require('./routes/demos')(express));
 // Iotivty api is rest one, so need to implement different response (json) and its timeout handling
 // TODO: In future add keep alive mechanism
 if (sthingsEnabled) {

--- a/libs/util.js
+++ b/libs/util.js
@@ -1,5 +1,6 @@
 var config = require('config');
 var debug = require('debug')('libs:util');
+var User = require('../models/user');
 
 exports.isLoggedIn = function (req, res, next) {
   // if user is authenticated in the session, carry on
@@ -18,3 +19,42 @@ exports.isAuthenticated = function(req, res, next) {
 
   return next();
 };
+
+// This is needed to allow opening WATT samples without user authentication.
+exports.authenticateAsAnonymous = function(req, res, next) {
+  // Find anonymous user.
+  const annonymousEmail = "annonymoususer@watt.com";
+  User.findOne({ 'local.email' : annonymousEmail }, function(err, user) {
+    if (err) {
+      res.status(404).send('Can not find anonymous user: ' + JSON.stringify(err));
+      return;
+    }
+
+    // If anonymous user does not exist, create it.
+    if (!user) {
+      user = new User();
+      user.local.email = annonymousEmail;
+      user.local.password = user.generateHash("pass");
+      user.save(function(err) {
+        if (err) {
+          res.status(404).send('Can not create anonymous user: ' + JSON.stringify(err));
+          return;
+        }
+        authenticateUser(req, res, next, user);
+      });
+    } else {
+      // authenticate anonymous user.
+      authenticateUser(req, res, next, user);
+    }
+  });
+};
+
+function authenticateUser(req, res, next, user) {
+  req.login(user, function(err) {
+    if (err) {
+      res.status(404).send('Can not login: ' + JSON.stringify(err));
+      return;
+    }
+    next();
+  });
+}

--- a/routes/demos.js
+++ b/routes/demos.js
@@ -1,0 +1,95 @@
+const path = require('path');
+const async = require('async');
+const Project = require('../models/project');
+const fs = require('fs');
+const fse = require('fs-extra');
+const authenticateAsAnonymous = require('../libs/util').authenticateAsAnonymous;
+
+module.exports = function (express) {
+  var router = express.Router();
+  router.get('/:name/:profile/:majorVersion.:minorVersion/:type',
+    authenticateAsAnonymous,
+    (req, res) => {
+      let projectId;
+      async.waterfall([
+
+        // Create new project.
+        callback => {
+          const newProject = new Project();
+          newProject.name = req.params.name;
+          newProject.user = req.user._id;
+          newProject.created = new Date();
+          newProject.profile = req.params.profile;
+          newProject.version = req.params.majorVersion + '.' + req.params.minorVersion;
+          newProject.type = req.params.type;
+          newProject.save((error, project) => {
+            if (error) {
+              return callback(error);
+            }
+            callback(null, project);
+          });
+        },
+
+        // Create project's dir in demos folder.
+        (project, callback) => {
+          projectId = project._id.toString();
+          const projectPath = path.join(process.cwd(), 'projects', projectId);
+          fse.ensureDir(projectPath, function (error) {
+            if (error) {
+              return callback(error);
+            }
+            callback(null, project, projectPath);
+          });
+        },
+
+        // Copy requested demo to the project.
+        (project, projectPath, callback) => {
+          // TODO: take the sample from external url.
+          const samplePath = path.join(process.cwd(), 'sample', project.type, project.name);
+          fse.copy(samplePath, projectPath, function (err) {
+            if (err) {
+              return callback(err);
+            }
+            callback(null, project);
+          });
+        },
+
+        // Create support folder.
+        (project, callback) => {
+          const supportPath = path.join(process.cwd(), 'projects', 'support', projectId);
+          fse.ensureDir(supportPath, function (error) {
+            if (error) {
+              return callback(error);
+            }
+            callback(null, project, supportPath);
+          });
+        },
+
+        // Add state.json to support folder.
+        (project, supportPath, callback) => {
+          const state = require(path.join(process.cwd(), 'models', 'state.json'));
+          state.projectId = projectId;
+          state.projectName = project.name;
+          state.projectType = project.type;
+          state.projectProfile = project.profile;
+          state.projectVersion = project.version;
+          state.projectExtension = "";
+          console.log(JSON.stringify(state));
+          fs.writeFile(path.join(supportPath, 'state.json'), JSON.stringify(state), () => callback(null, project, supportPath));
+        },
+
+        // Add brackets.json to support folder.
+        (project, supportPath, callback) => {
+          console.log("6");
+          const brackets = require(path.join(process.cwd(), 'models', 'brackets.json'));
+          fs.writeFile(path.join(supportPath, 'brackets.json'), JSON.stringify(brackets), () => res.redirect('/brackets/' + projectId));
+        }
+      ], error => {
+          if (error) {
+            res.status(400).send('Can not open demo. ' + error);
+          }
+        }
+    )
+  });
+  return router;
+};


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TIZENWF-2199
[Problem] To open any project/sample user has to be authenticated.
          It's required from WATT to allow opening the requested
          sample without authentication, for example,

          http://WATT_address:3000/demos/TAUBaseApplication/wearable/3.0/web

[Solution] Add rest API "/demos" to create brackets project from sample (name/profile/version/type)
           needs to be given. Add and authenticate anonymous user to open
           brackets project.

[Remarks] After opening sample demo as anonymous it's possible
          to open other user's projects by accessing /brackets/projectId.
          But this may be general issue (not strictly connected to anonymous user).

[TEST]
        1. Open http://localhost:3000/demos/TAUBaseApplication/wearable/3.0/web
        2. TAUBaseApplication application should be opened in brackets.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>