### PR TITLE
[Docker] Use Asia (Seoul) region while setting AWS

### DIFF
--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -2,21 +2,21 @@ version: '3'
 
 services:
   mongo_container:
-    image: 894081267860.dkr.ecr.us-east-2.amazonaws.com/mongo_docker_repository
+    image: 894081267860.dkr.ecr.ap-northeast-2.amazonaws.com/mongo_docker_repository
     restart: always
     logging:
       driver: awslogs
       options:
-        awslogs-region: us-east-2
+        awslogs-region: ap-northeast-2
         awslogs-group: watt-awslogs-group
         awslogs-stream-prefix: mongo
 
   watt_container:
-    image: 894081267860.dkr.ecr.us-east-2.amazonaws.com/watt_docker_repository
+    image: 894081267860.dkr.ecr.ap-northeast-2.amazonaws.com/watt_docker_repository
     logging:
       driver: awslogs
       options:
-        awslogs-region: us-east-2
+        awslogs-region: ap-northeast-2
         awslogs-group: watt-awslogs-group
         awslogs-stream-prefix: watt
     ports:


### PR DESCRIPTION
[Issue] N/A
[Problem] Lack of instruction how to set up aws instance in Asia region.
[Solution] Update README.md and docker-compose-aws.yml file.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>