### PR TITLE
Fetch TAU samples from TAU page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,16 @@ RUN apt-get update && \
         android-tools-adb \
         git \
         python-pip \
-        curl \
         build-essential \
         cmake \
         ca-certificates \
         libc6:i386 \
         pciutils \
-        curl \
+        wget \
         zip && \
     apt-get -o Dpkg::Options::="--force-overwrite" install -y \
         openjdk-8-jdk && \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    wget -qO- https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y nodejs && \
     apt-get -y clean && \
     apt-get -y autoclean && \
@@ -53,7 +52,7 @@ USER watt_user
 WORKDIR /home/watt_user/
 
 # Download and install (latest) Tizen Studio 3.2 into default ~/tizen-studio (for user certificate creation)
-RUN curl -sL http://download.tizen.org/sdk/Installer/tizen-studio_3.2/web-cli_Tizen_Studio_3.2_ubuntu-64.bin > web-cli_Tizen_Studio_3.2_ubuntu-64.bin && \
+RUN wget -qO- http://download.tizen.org/sdk/Installer/tizen-studio_3.2/web-cli_Tizen_Studio_3.2_ubuntu-64.bin > web-cli_Tizen_Studio_3.2_ubuntu-64.bin && \
     chmod +x web-cli_Tizen_Studio_3.2_ubuntu-64.bin && \
     mkdir /home/watt_user/tizen-studio && \
     ./web-cli_Tizen_Studio_3.2_ubuntu-64.bin --accept-license /home/watt_user/tizen-studio && \
@@ -63,7 +62,7 @@ RUN curl -sL http://download.tizen.org/sdk/Installer/tizen-studio_3.2/web-cli_Ti
 # Latest version is unable to pack to wgt once user cert is specified
 # More details at http://suprem.sec.samsung.net/jira/browse/TIZENWF-2298
 # or https://developer.tizen.org/ko/forums/sdk-ide/pwd-fle-format-profile.xml-certificates?langredirect=1
-RUN curl -sL http://download.tizen.org/sdk/Installer/tizen-studio_2.5/web-cli_Tizen_Studio_2.5_ubuntu-64.bin > web-cli_Tizen_Studio_2.5_ubuntu-64.bin && \
+RUN wget -qO- http://download.tizen.org/sdk/Installer/tizen-studio_2.5/web-cli_Tizen_Studio_2.5_ubuntu-64.bin > web-cli_Tizen_Studio_2.5_ubuntu-64.bin && \
     chmod +x web-cli_Tizen_Studio_2.5_ubuntu-64.bin && \
     mkdir /home/watt_user/tizen-studio-2.5 && \
     ./web-cli_Tizen_Studio_2.5_ubuntu-64.bin --accept-license /home/watt_user/tizen-studio-2.5 && \

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
     "DBHost": "mongodb://localhost:27017/watt",
-    "PORT": 3000
+    "PORT": 3000,
+    "TAUExamplesHost": "https://samsung.github.io/TAU/examples/"
 }

--- a/launch
+++ b/launch
@@ -74,13 +74,11 @@ def install_nodejs():
     Log.info('Install nodejs with "brew"')
     cmds = ['brew update', 'brew install node']
   else:
-    status = subprocess.call('which curl > /dev/null', shell=True)
-    if status != 0 and not install_deb_package('curl'):
-      Log.err('Fail to install curl')
-      sys.exit(1)
+    if not ensure_deb_package('wget'):
+      return False;
 
     Log.info('Install nodejs with "apt-get" (sudo privileges required)')
-    cmds = ['curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -', \
+    cmds = ['wget -qO- https://deb.nodesource.com/setup_10.x | sudo -E bash -', \
       'sudo apt-get install -y nodejs']
 
   try:


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TIZENWF-2567
[Problem] WATT does not have all TAU samples
[Solution] Fetch TAU samples from https://samsung.github.io/TAU/examples/
           while requesting /demos API with sample path as query parameter, for example
           http://localhost:3000/demos/?path=mobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html
           Since wget is used to download page, curl has been removed in favor of wget.
[TEST]
    1. Create sample html with the following content:
      <html>
        <body>
          <script>
            window.open("http://localhost:3000/demos/?path=" + encodeURIComponent("mobile/UIComponents/components/controls/checkbox.html"));
          </script>
        </body>
      </html>
      Alternatively, you can manually encode path by replacing '/' with '%2F'.

    2. Brackets project should be opened without user authentication.

[Remarks]
    white page while downloading sample (this takes arround ~20 second)
    DE does not start - lack of config.xml
    missing images in tau, wget error checking is skiped now

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>