### PR TITLE
Add config.xml to downloaded TAU project

### DIFF
--- a/models/config.xml
+++ b/models/config.xml
@@ -3,7 +3,7 @@
     <tizen:application id="" package="" required_version=""/>
     <content src="index.html"/>
     <feature name="http://tizen.org/feature/screen.size.all"/>
-    <icon src="icon.png"/>
+    <icon src=""/>
     <name></name>
     <tizen:profile name=""/>
 </widget>


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TIZENWF-2567
[Problem] Deasign Editor does not start and tizen packaging does not
               generate wgt file.
[Solution] Add config.xml and fill its content
[Remarks] Although config.xml is added, DE still does not start.
                This issue is reported http://suprem.sec.samsung.net/jira/browse/TIZENWF-2580
[TEST]
    1. Create sample html with the following content:
      <html>
        <body>
          <script>
            window.open("http://localhost:3000/demos/?path=" + encodeURIComponent("mobile/UIComponents/components/controls/checkbox.html"));
          </script>
        </body>
      </html>
      Alternatively, you can manually encode path by replacing '/' with '%2F'.
    
    2. config.xml should exist in root directory.
