### PR TITLE
Enable eslint verification in travis

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,7 @@
-libs/iotivity.js
+libs/brackets-server/brackets-src/**
+tools/crx/**
+tools/pepper.js/tools/video.js/mux-js/**
+libs/tau-wysiwig/**
+**/node_modules/**
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: node_js
-
 git:
   submodules: false
-
 os: linux
 dist: xenial
 sudo: enabled
-
 install:
-    - ./launch -d
+- "./launch -d"
+script:
+- npm run lint-check
+- npm test
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./app.js",
-    "test": "make test"
+    "test": "make test",
+    "lint-check": "lint-diff $TRAVIS_COMMIT_RANGE"
   },
   "nyc": {
     "exclude": [
@@ -55,12 +56,14 @@
     "babel-eslint": "^10.0.1",
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
+    "eslint": "^5.16.0",
     "grunt-contrib-csslint": "^2.0.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^21.0.0",
     "grunt-gitnewer": "^1.0.5",
     "grunt-html": "^8.4.0",
+    "lint-diff": "^1.2.1",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.2.0",
     "node-mocks-http": "^0.0.6",


### PR DESCRIPTION
Enable eslint verification in travis

[Issue] N/A
[Problem] No eslint verification in project
[Solution] Use lint-dfff from [1]

[1] https://www.npmjs.com/package/lint-diff

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>