### PR TITLE
Remove PORT from config/docker.json

### DIFF
--- a/config/docker.json
+++ b/config/docker.json
@@ -1,4 +1,3 @@
 {
-    "DBHost": "mongodb://mongo_container:27017/watt",
-    "PORT": 3000
+    "DBHost": "mongodb://mongo_container:27017/watt"
 }


### PR DESCRIPTION
[Issue] N/A
[Problem] Unnecessary PORT definition since docker uses the same port number as
    WATT which is taken from config/default.json.
[Solution] Remove PORT from config/docker.json
 [TEST] ./docker-run.sh --rebuild

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>