### PR TITLE
Fix launch check in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ os: linux
 dist: xenial
 sudo: enabled
 install:
-- "./launch -d"
+# avoid default npm install
+- true
 script:
+- "./launch -d"
 - npm run lint-check
 - npm test
 


### PR DESCRIPTION
[Issue] N/A
[Problem] When launch -d fails it is not reported by travis
[Reason] Travis reports failure only when jobs from script
section fail.
[Solution] Move launch to script section

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>