### PR TITLE
Let wget report errors to user

### DIFF
--- a/routes/demos.js
+++ b/routes/demos.js
@@ -58,9 +58,7 @@ module.exports = function (express) {
           exec(`wget --page-requisites --convert-links --no-host-directories --cut-dirs=${numDirsToCut} --directory-prefix ${projectPath} ${sampleUrl}`, (error, stdout, stderr) => {
             if (error) {
               console.log(error);
-              // FIXME: background-image's url from tau.css references file that
-              // does not exist on server. Uncomment line below once it's fixed.
-              // return callback(error);
+              return callback(`Could not download sample from ${sampleUrl}`);
             }
             callback(null, project, projectPath);
           });


### PR DESCRIPTION
[Issue] N/A
[Problem] Empty brackets project is created once users passes
    not valid path to TAU sample.
[Solution] Restore wget error checking which was reported https://github.com/Samsung/TAU/issues/77

[TEST positive]
   1. Open http://localhost:3000/demos/?path=mobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html
   2. Brackets project should be created and index.html should be opened.

[TEST negative]
   1. Open http://localhost:3000/demos/?path=WRONGPATH.html
   2. Error should be visible to user.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>