### PR TITLE
Do not delete project owned by different user

### DIFF
--- a/public/js/project.js
+++ b/public/js/project.js
@@ -452,7 +452,7 @@ $('#delete-project').on('show.bs.modal', function(evt) {
 
   $('#delete-button').on('click', function() {
     $.ajax({
-      url: '/project/'+id,
+      url: '/project/' + id,
       type: 'delete'
     }).done(function() {
       $.get('/update').done(function(data) {
@@ -465,7 +465,9 @@ $('#delete-project').on('show.bs.modal', function(evt) {
         $('#delete-project').modal('hide');
       });
     }).fail(function(err) {
+      $('#delete-project').modal('hide');
       console.error(err);
+      window.alert(err.responseText);
     });
   });
 });


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TIZENWF-2611
[Poblem] User 'foo' can delete project created by user 'bar'.
[Solution] Check current user before deleting project.
           In addition, prohibit anonymous user from deleting his
           projects as they are expected to be removed by WATT itself (not implemented).
[TEST]
    1. Sing up and login in as foo@watt.com.
    2. Create sample web application (for example, TAUBaseApplication).
    3. Open newly create project and copy its id.
    4. Logout
    5. Sing up and login in as bar@watt.com.
    6. Create sample web application (for example, TAUBaseApplication).
    7. Paste foo's project id into the code below
        public/js/project.js
           ...
           $('#delete-button').on('click', function() {
             $.ajax({
                url: '/project/'+ 'PROJECT_ID_FROM_FOO_USER',
           ...
    8. Restart WATT.
    9. Login in as bar@watt.com.
    10. Try to delete project.
    11. Alert should be displayed with message "Not current user".

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>