### PR TITLE
Download resources recursively - Number Picker example fix

### DIFF
--- a/routes/demos.js
+++ b/routes/demos.js
@@ -62,7 +62,7 @@ module.exports = function (express) {
             else {
               // Define number of unnecessary directories to be omitted while downloading.
               const numDirsToCut = sampleUrl.pathname.match(/TAU\/examples\/mobile|wearable\/UIComponents/g) ? 4 : 0;
-              exec(`wget --page-requisites --convert-links --no-host-directories --cut-dirs=${numDirsToCut} --directory-prefix ${projectPath} ${sampleUrl}`, (error, stdout, stderr) => {
+              exec(`wget --recursive --page-requisites --convert-links --no-host-directories --cut-dirs=${numDirsToCut} --directory-prefix ${projectPath} ${sampleUrl}`, (error, stdout, stderr) => {
                 if (error) {
                   // we don't return here because there may be samples with not existing resources
                   console.log(error);


### PR DESCRIPTION
[Issue] N/A
[Problem] Entries in Number Picker example don't work
[Cause] html files are not downloaded by wget
[Solution] Add -r (recusrsive) option to wget download
[Test]
1. Visit localhost:3000/demos?path=wearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html
2. Open DE
3. Click preview button
4. Click on Simple/Accelerated links
Expected:
Links should be working correctly