### PR TITLE
Clean outdated anonymous projects

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -2,5 +2,7 @@
     "DBHost": "mongodb://localhost:27017/watt",
     "PORT": 3000,
     "TAUExamplesHost": "https://samsung.github.io/TAU/examples/",
-    "AnonymousEmail": "anonymoususer@watt.com"
+    "AnonymousEmail": "anonymoususer@watt.com",
+    "AnonymousProjectsLimit": 100,
+    "AnonymousProjectsDeprecationAgeInMinutes": 60
 }


### PR DESCRIPTION
[Issue] N/A 
[Problem] Disk usage increase.
[Solution] Add limitation to 100 projects for projects created by anonymous user. Once this
    number is reached, anonymous projects older than one hour are deleted.

[TEST] Require no code/logic changes.

    1. Open http://localhost:3000/demos/?path=mobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html
       100 times.
    2. Open http://localhost:3000/demos/?path=mobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html again
    3. You should see 'No possible to create more demos. Please try again later.'
    4. Wait one hour.
    5. Open http://localhost:3000/demos/?path=mobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html
    6. Sample should be opened.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>
