### PR TITLE
[Docker] Add --no-cache parameter to docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ usermod: user 'foo' does not exist
 ```bash
 ./docker-run.sh
 ```
+
+* This pulls and builds necessary images if they do not exists on local machine. Otherwise, docker tries to use existing images even if they are out of dated. Add '--rebuild' paramter in order to create new image.
+
 * Ensure 3000 port to be free. You should see logs on terminal:
 ```bash
 watt_container_1   | Listening on port 3000
@@ -128,7 +131,7 @@ docker container exec -i 12cf98736487 bash
 ## Pushing docker images to AWS repositories
  * Make sure your .git folder is not huge since its size significantly increases docker image.
 ```bash
-./docker-run.sh
+./docker-run.sh --rebuild
 ```
  * List docker images:
 ```bash

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -13,10 +13,9 @@ if [ "$CONT" = "y" ]; then
   if [ "$1" = "--rebuild" ]; then
     echo "Rebuilding ..."
     docker-compose down
-    docker-compose build
+    docker-compose build --no-cache
     if [ $? -ne 0 ]; then
         echo "Could not rebuild images"
-        echo "Try to add --no-cache option to docker-compose build"
         exit 1
     fi
   fi


### PR DESCRIPTION
[Issue] N/A
[Problem] Docker uses cached local resources while building images. This is potential
    issue for user who already used docker for WATT. In this case
    docker will not process them.
[Solution] Add --no-cache parameter. In addition, update README.md how to use
    docker-run.sh.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>