### PR TITLE
[Docker] Extract common functionality to separate script

### DIFF
--- a/docker-common.sh
+++ b/docker-common.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+watt_source_init() {
+    read -p "This will clean WATT and its submodules (node_modules, untracked files etc). Are you sure (y/n)?" CONT
+    if [ "$CONT" = "y" ]; then
+      echo "Cleaning ..."
+      git clean -xfdf
+
+      echo "Init ..."
+      # Ensure all submodules sources here. Docker image does not
+      # have access to repositories.
+      ./update_submodules
+    fi
+}
+
+docker_compose_build() {
+    echo "Building ..."
+    docker-compose down
+    docker-compose build --no-cache
+    if [ $? -ne 0 ]; then
+        echo "Could not build images"
+        exit 1
+    fi
+}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,25 +1,13 @@
 #!/bin/bash
 
-read -p "This will clean WATT and its submodules (node_modules, untracked files etc). Are you sure (y/n)?" CONT
-if [ "$CONT" = "y" ]; then
-  echo "Cleaning ..."
-  git clean -xfdf
+DIR="${BASH_SOURCE%/*}"
+. "$DIR/docker-common.sh"
 
-  echo "Init ..."
-  # Ensure all submodules sources here. Docker image does not
-  # have access to repositories.
-  ./update_submodules
+watt_source_init
 
-  if [ "$1" = "--rebuild" ]; then
-    echo "Rebuilding ..."
-    docker-compose down
-    docker-compose build --no-cache
-    if [ $? -ne 0 ]; then
-        echo "Could not rebuild images"
-        exit 1
-    fi
-  fi
-
-  echo "Composing ..."
-  docker-compose up
+if [ "$1" = "--rebuild" ]; then
+    docker_compose_build
 fi
+
+echo "Running ..."
+docker-compose up

--- a/docker-watt-image-push.sh
+++ b/docker-watt-image-push.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DIR="${BASH_SOURCE%/*}"
+. "$DIR/docker-common.sh"
+
+watt_source_init
+docker_compose_build
+
+echo "Upload to AWS is not implemented yet. Do it manually"


### PR DESCRIPTION
[Issue] N/A
[Problem] To push watt image to AWS repositories, docker-run.sh
          script must be launched with --rebuild parameter and
          user unnecessary has to wait for docker-compose up
          (which runs docker image).
[Solution] Create docker-common.sh including common functionality
           used by docker-run.sh and docker-watt-image-push.sh

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>