### PR TITLE
Fix examples opening in WATT

### DIFF
--- a/routes/demos.js
+++ b/routes/demos.js
@@ -156,7 +156,7 @@ module.exports = function (express) {
             }
             else {
               // Define number of unnecessary directories to be omitted while downloading.
-              const numDirsToCut = sampleUrl.pathname.match(/TAU\/examples\/mobile|wearable\/UIComponents/g) ? 4 : 0;
+              const numDirsToCut = sampleUrl.pathname.match(/TAU\/examples\/+.+\/examples\/mobile|wearable\/UIComponents/g) ? 6 : 0;
               exec(`wget --recursive --page-requisites --convert-links --no-host-directories --cut-dirs=${numDirsToCut} --directory-prefix ${projectPath} ${sampleUrl}`, (error, stdout, stderr) => {
                 if (error) {
                   // we don't return here because there may be samples with not existing resources
@@ -172,8 +172,8 @@ module.exports = function (express) {
         (project, projectPath, callback) => {
           const isMobileProfile = req.query.path.includes('mobile');
           const isWerableProfile = req.query.path.includes('wearable');
-          const componentMobile = path.join('mobile', 'UIComponents');
-          const componentWerable = path.join('wearable', 'UIComponents');
+          const componentMobile = path.join('+.+', 'examples', 'mobile', 'UIComponents');
+          const componentWerable = path.join('+.+', 'examples', 'wearable', 'UIComponents');
 
           util.createConfigXML(projectPath,
             {

--- a/test/demosTest.js
+++ b/test/demosTest.js
@@ -77,7 +77,7 @@ describe('test demos.js', () => {
   describe('test successfull demo download', () => {
     it('should succeed', (done) => {
       chai.request(server)
-        .get('/demos?path=wearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html')
+        .get('/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html')
         .end((error,res) => {
           res.status.should.equal(200);
           done();


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/188
[Problem] index.html is not opened
[Reason] Additional 2 directories on the path
[Solution] Take into account two additional directories on the path
[Test] Visit following examples and make sure that index.html is opened

http://localhost:3000/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html
http://localhost:3000/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fcheckbox.html
http://localhost:3000/demos?path=1.0%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fcontrols%2Fcheckbox.html

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>