### PR TITLE
Disable login feature for docker

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,7 +80,11 @@ app.use('/components/jquery', express.static(path.join(__dirname, 'node_modules'
 app.use('/components/magnific-popup', express.static(path.join(__dirname, 'node_modules', 'magnific-popup', 'dist')));
 app.use('/components/scrollreveal', express.static(path.join(__dirname, 'node_modules', 'scrollreveal', 'dist')));
 
-app.use('/', require('./routes/index')(express, passport));
+// For docker envrionment we disable user login feature
+if (config.util.getEnv('NODE_ENV') !== 'docker') {
+  app.use('/', require('./routes/index')(express, passport));
+}
+
 app.use('/import', require('./routes/import')(express));
 app.use('/export', require('./routes/export')(express));
 app.use('/project', require('./routes/project')(express));

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -35,7 +35,6 @@
 
           <p>
             We could not find the page you were looking for.
-            Meanwhile, you may <a href="/">return to dashboard</a>.
           </p>
 
         </div>


### PR DESCRIPTION
[Issue] N/A
[Problem] In docker environment user can log in
[Solution] Check env variable and enable index site only for non-docker
environment
[Test]
1. Launch WATT
2. Visit localhost:3000 (no error)
3. Visit http://localhost:3000/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html (no error)
4. Launch WATT in docker environment
5. Visit localhost:3000 (error)
6. Visit http://localhost:3000/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html (no error)

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>