### PR TITLE
[Docker] Push watt docker image to AWS repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,22 +130,13 @@ docker container exec -i 12cf98736487 bash
 
 ## Pushing docker images to AWS repositories
  * Make sure your .git folder is not huge since its size significantly increases docker image.
-```bash
-./docker-run.sh --rebuild
-```
- * List docker images:
-```bash
-docker images
-```
- * Sample output:
-```bash
-watt_watt_container                                                               latest              fa2fc69d89a1        5 days ago          3.36GB
-mongo                                                                             3.4.19              056cb4b05c15        5 weeks ago         376MB
-```
  * [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html)
- * Push watt and mongo images to [aws repositories](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html#use-ecr) to desired region. To push the image to [Asia Pacific Seoul](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) you can pass --region ap-northeast-2 while creating repository..
- * If you need to update WATT image only, just tag your local watt image with Uri from [repositories](https://us-east-2.console.aws.amazon.com/ecr/repositories?region=ap-northeast-2) and push the image.
- * Images should be available at [repositories](https://us-east-2.console.aws.amazon.com/ecr/repositories?region==ap-northeast-2).
+ * Build and push watt docker image to AWS repositories
+```bash
+./docker-watt-image-push.sh AWS_ACCOUNT_ID
+```
+ * If you need additional steeps, for example, updating mongod image or create new repository just follow [this guide.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html#use-ecr)
+ * Images should be available at [repositories](https://ap-northeast-2.console.aws.amazon.com/ecr/repositories?region=ap-northeast-2#).
 
 ## Creating cluster
  * You can omit steeps below in order to use already existing watt cluster.

--- a/docker-watt-image-push.sh
+++ b/docker-watt-image-push.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
+# Usage:
+# ./docker-watt-image-push.sh AWS_ACCOUNT_ID
+
+if [ -z "$1" ]; then
+    echo "Please give your aws account id as first param."
+    exit 1
+fi
+
 DIR="${BASH_SOURCE%/*}"
 . "$DIR/docker-common.sh"
 
 watt_source_init
 docker_compose_build
 
-echo "Upload to AWS is not implemented yet. Do it manually"
+# Get the recent watt image.
+local_watt_image=`docker images | awk '{print $1}' | awk 'NR==2'`
+if [[ $local_watt_image != *watt_container ]]; then
+  echo "Could not found watt image"
+  exit 1
+fi
+
+echo -e "\033[0;32mImage to be pushed: \033[0m"
+docker images | awk 'NR==2'
+
+aws_account_id=$1
+region=ap-northeast-2
+watt_docker_aws_repository_uri=$aws_account_id.dkr.ecr.$region.amazonaws.com/watt_docker_repository
+
+# Find and remove previously tagged image.
+if docker images | awk '{print $1}' | grep -q $watt_docker_aws_repository_uri
+then
+    docker image rm $watt_docker_aws_repository_uri
+    if [ $? -ne 0 ]; then
+        echo "Could not remove "$watt_docker_aws_repository_uri
+        exit 1
+    fi
+    echo -e "\033[0;32mSuccessfully removed \033[0m"$watt_docker_aws_repository_uri
+fi
+
+# Tag watt image with repository Uri.
+docker tag $local_watt_image $watt_docker_aws_repository_uri
+if [ $? -ne 0 ]; then
+    echo "Could not tag images"
+    exit 1
+fi
+
+# Login to aws.
+aws ecr get-login --no-include-email --region $region | bash -
+if [ $? -ne 0 ]; then
+    echo "Could not login"
+    exit 1
+fi
+
+# Push the image to repository Uri.
+docker push $watt_docker_aws_repository_uri
+if [ $? -ne 0 ]; then
+    echo "Could not push images"
+    exit 1
+fi
+
+echo -e "\033[0;32mSuccessfully pushed watt image to \033[0m"$watt_docker_aws_repository_uri


### PR DESCRIPTION
[Issue] N/A
[Problem] User has to perform many actions manually
          to push watt docker image to AWS repositories
[Solution] Let docker-watt-image-push.sh do this automatically.
[Test] ./docker-watt-image-push.sh AWS_ACCOUNT_ID


Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>