### PR TITLE
Change use tau bundled with external libraries in samples

### DIFF
--- a/sample/web/TAU_1.1_Base_Mobile/index.html
+++ b/sample/web/TAU_1.1_Base_Mobile/index.html
@@ -19,6 +19,6 @@
 		</div><!-- /content -->
 	</div><!-- /page -->
 
-	<script type="text/javascript" src="lib/tau/mobile/js/tau.js"></script>
+	<script type="text/javascript" src="lib/tau/mobile/js/tau.bundle.js"></script>
 </body>
 </html>

--- a/sample/web/TAU_1.1_Base_Wearable/index.html
+++ b/sample/web/TAU_1.1_Base_Wearable/index.html
@@ -17,7 +17,7 @@
 			<p>Hello! </p>
 		</div>
 	</div>
-	<script src="lib/tau/wearable/js/tau.min.js"></script>
+	<script src="lib/tau/wearable/js/tau.bundle.js"></script>
 	<script src="js/lowBatteryCheck.js"></script>
 	<script src="js/circle-helper.js"></script>
 </body>

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/button/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/button/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/button/textButton.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/button/textButton.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/checkbox.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/checkbox.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/dimmer.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/dimmer.html
@@ -4,7 +4,7 @@
 	<meta name="viewport" content="width=device-width,user-scalable=no"/>
 	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<script type="text/javascript" src="../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../lib/tau/mobile/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 <div class="ui-page" id="dimmer-page">

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/dropdownmenu.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/dropdownmenu.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/floatingactions/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/floatingactions/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/floatingactions/on-listview.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/floatingactions/on-listview.html
@@ -4,7 +4,7 @@
 	<meta name="viewport" content="width=device-width,user-scalable=no"/>
 	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.min.css">
 	<link rel="stylesheet" href="../../../css/style.css">
-	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 	<div class="ui-page" id="pageFloatingButton">

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/floatingactions/on-page.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/floatingactions/on-page.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/activity.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/activity.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/activitybar.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/activitybar.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/activitycircle.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/activitycircle.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/progressbar.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/progressbar.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/progresscircle.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/progress/progresscircle.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/radio.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/radio.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/scrollhandler.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/scrollhandler.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/scrollhandler/horizontal.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/scrollhandler/horizontal.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/scrollhandler/vertical.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/scrollhandler/vertical.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchbar/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchbar/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchbar/searchbar-with-icon.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchbar/searchbar-with-icon.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchbar/searchbar.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchbar/searchbar.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchinput/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/searchinput/index.html
@@ -6,7 +6,7 @@
 	<link href="styles.css" rel="stylesheet" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/slider.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/slider.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/textenveloper-selectable.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/textenveloper-selectable.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/textenveloper-static.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/textenveloper-static.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/textenveloper.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textenveloper/textenveloper.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textinput.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/textinput.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/toggleswitch.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/controls/toggleswitch.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/gallery/gallery.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/gallery/gallery.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/graphs/bar_graph.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/graphs/bar_graph.html
@@ -26,9 +26,6 @@
 			</li>
 		</ul>
         </div><!-- /content -->
-		<script src="../../lib/tau/libs/d3.min.js" charset="utf-8"></script>
-		<script src="../../lib/tau/libs/tauCharts.min.js" type="text/javascript"></script>
-        <link rel="stylesheet" type="text/css" href="../../lib/tau/libs/tauCharts.min.css">
         <script src="bar_graph.js"></script>
 </div><!-- /page -->
 </body>

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/graphs/dynamic_graph.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/graphs/dynamic_graph.html
@@ -29,9 +29,6 @@
         <div class="ui-footer" data-position="fixed">
                 <button id="button">Start</button>
         </div><!-- /footer-->
-		<script src="../../lib/tau/libs/d3.min.js" charset="utf-8"></script>
-		<script src="../../lib/tau/libs/tauCharts.min.js" type="text/javascript"></script>
-        <link rel="stylesheet" type="text/css" href="../../lib/tau/libs/tauCharts.min.css">
         <script src="dynamic_graph.js"></script>
 </div><!-- /page -->
 </body>

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/graphs/static_graph.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/graphs/static_graph.html
@@ -28,9 +28,6 @@
 			</li>
 		</ul>
 		</div><!-- /content -->
-		<script src="../../lib/tau/libs/d3.min.js" charset="utf-8"></script>
-		<script src="../../lib/tau/libs/tauCharts.min.js" type="text/javascript"></script>
-		<link rel="stylesheet" type="text/css" href="../../lib/tau/libs/tauCharts.min.css">
 </div><!-- /page -->
 </body>
 </html>

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/bottombutton.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/bottombutton.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/lefticon.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/lefticon.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/lefttext.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/lefttext.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/multiline.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/multiline.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/righticon.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/righticon.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/righttext.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/righttext.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/twoicons.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/twoicons.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/twotext.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/header/twotext.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/headerfooter/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/interactive/coverflow/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/interactive/coverflow/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta name="viewport" content="width=device-width,user-scalable=no"/>
 	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.css">
-	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 <div class="ui-page" id="demo-page">

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/interactive/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/interactive/index.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<script type="text/javascript" src="../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../lib/tau/mobile/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 <div class="ui-page" id="demo-page">

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/interactive/interactive3D/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/interactive/interactive3D/index.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../../css/style.css">
-	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 <div data-role="page" class="ui-page" id="demo-i3d-page">

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/expandable/expandable-js.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/expandable/expandable-js.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/expandable/expandable.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/expandable/expandable.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-with-label-1.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-with-label-1.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-with-label-2.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-with-label-2.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-with-move.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-with-move.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-within-popup.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview-within-popup.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridview.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridwithbadge.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridwithbadge.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridwithcheck.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/gridview/gridwithcheck.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/liststyles.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/liststyles.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/normallist.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/normallist.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/on-off.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/on-off.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/reorder.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/reorder.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/selectall.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/selectall.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_1line_btn.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_1line_btn.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_1line_icon.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_1line_icon.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_2line_star.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_2line_star.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_normal.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/list/virtuallist_normal.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/multimediaview/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/multimediaview/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/multimediaview/multimediaview_audio.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/multimediaview/multimediaview_audio.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/multimediaview/multimediaview_video.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/multimediaview/multimediaview_video.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/indexscrollbar.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/indexscrollbar.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/indexscrollbar_floating_button.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/indexscrollbar_floating_button.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/pageindicator.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/pageindicator.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/pageindicatorDotted.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/pageindicatorDotted.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/panel/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/panel/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/light_view.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/light_view.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_2.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_2.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_3.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_3.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_4.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_4.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_scroll.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_icon_with_title_scroll.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_2.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_2.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_3.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_3.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_4.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_4.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_scroll.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_scroll.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_with_buttons.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_text_only_with_buttons.html
@@ -64,6 +64,6 @@
 		</div>
 	</div>
 </div>
-<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.bundle.js" data-build-remove="false"></script>
 </body>
 </html>

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_badge.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_badge.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_2.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_2.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_3.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_3.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_4.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_4.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_scroll.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_icon_scroll.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_2.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_2.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_3.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_3.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_4.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_4.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_scroll.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/navigationelements/tabs/tabs_with_title_scroll.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/ctxpopup.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/ctxpopup.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/gridview.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/gridview.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/gridviewmultiple.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/gridviewmultiple.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/moremenufooter.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/moremenufooter.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/moremenuheader.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/moremenuheader.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/popup.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/popup.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/toast.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/popup/toast.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/detailList.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/detailList.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state-search-with-floatingactions.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state-search-with-floatingactions.html
@@ -6,7 +6,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state-search.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state-search.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state-with-floating-action.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state-with-floating-action.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/empty-state.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/emptystate/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/footer/three-bottom-buttons.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/footer/three-bottom-buttons.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/index.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/textinputwithbutton.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/textinputwithbutton.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/welcome.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/components/recommendations/welcome.html
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Mobile/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Mobile/index.html
@@ -8,7 +8,7 @@
 	</title>
 	<link href="lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="css/style.css" rel="stylesheet" />
-	<script data-build-remove="false" src="lib/tau/mobile/js/tau.js">
+	<script data-build-remove="false" src="lib/tau/mobile/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/content/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/content/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/big-icon-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/big-icon-button.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/icon-button-from-js.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/icon-button-from-js.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/icon-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/icon-button.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/long-text-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/long-text-button.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/short-text-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/short-text-button.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/small-icon-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/small-icon-button.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/text-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/button/text-button.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/checkbox.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/checkbox.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/colorpicker.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/colorpicker.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/date-picker.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/date-picker.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/dimmer.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/dimmer.html
@@ -19,5 +19,5 @@
 		<script src="dimmer.js"></script>
 	</div>
 </body>
-<script src="../../../lib/tau/wearable/js/tau.js"></script>
+<script src="../../../lib/tau/wearable/js/tau.bundle.js"></script>
 </html>

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/bottomButton.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/bottomButton.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/bottomButtonIcon.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/bottomButtonIcon.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/multipleButton.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/footer/multipleButton.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/hyperlink.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/hyperlink.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/icon-button.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/icon-button.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/indicator/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/indicator/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/indicator/pageindicator.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/indicator/pageindicator.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/indicator/pageindicator_circle.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/indicator/pageindicator_circle.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/marquee/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/marquee/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/numberpicker/accelerated.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/numberpicker/accelerated.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/numberpicker/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/numberpicker/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/numberpicker/simple.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/numberpicker/simple.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/full_processing.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/full_processing.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/load_more_contents.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/load_more_contents.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/sending.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/sending.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/small_processing.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/small_processing.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/small_processing_on_list.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/processing/small_processing_on_list.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_full.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_full.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_large.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_large.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_medium.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_medium.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_small.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_small.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_thickness.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/progress/progress_thickness.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/radio.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/radio.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/selector/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/selector/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/selector/selector-edit.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/selector/selector-edit.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/selector/selector.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/selector/selector.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/extended_slider.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/extended_slider.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/extended_slider_subtitle.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/extended_slider_subtitle.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/slider.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/slider/slider.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/text-input.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/text-input.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/time-picker.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/time-picker.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/time-picker24.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/time-picker24.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/toggle.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/controls/toggle.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/add-items-2-lines.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/add-items-2-lines.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/add-items.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/add-items.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/no-items-2-lines.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/no-items-2-lines.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/no-items.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/empty-state/no-items.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/etc/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/etc/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/graphs/bar_graph.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/graphs/bar_graph.html
@@ -22,9 +22,6 @@
 			 data-axis-x-type="order"
 			 data-axis-x-unit="s"></div>
         </div><!-- /content -->
-		<script src="../../lib/tau/libs/d3.min.js" charset="utf-8"></script>
-		<script src="../../lib/tau/libs/tauCharts.min.js" type="text/javascript"></script>
-        <link rel="stylesheet" type="text/css" href="../../lib/tau/libs/tauCharts.min.css">
         <script src="bar_graph.js"></script>
 </div><!-- /page -->
 </body>

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/graphs/dynamic_graph.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/graphs/dynamic_graph.html
@@ -25,9 +25,6 @@
 		<footer class="ui-footer ui-bottom-button ui-fixed">
 			<button class="ui-btn" id="button">Start</button>
 		</footer>
-		<script src="../../lib/tau/libs/d3.min.js" charset="utf-8"></script>
-		<script src="../../lib/tau/libs/tauCharts.min.js" type="text/javascript"></script>
-        <link rel="stylesheet" type="text/css" href="../../lib/tau/libs/tauCharts.min.css">
         <script src="dynamic_graph.js"></script>
 </div><!-- /page -->
 </body>

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/graphs/static_graph.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/graphs/static_graph.html
@@ -24,9 +24,6 @@
 			 data-axis-x-unit="s"
 			 data-value="[1,2,5]"></div>
 		</div><!-- /content -->
-		<script src="../../lib/tau/libs/d3.min.js" charset="utf-8"></script>
-		<script src="../../lib/tau/libs/tauCharts.min.js" type="text/javascript"></script>
-		<link rel="stylesheet" type="text/css" href="../../lib/tau/libs/tauCharts.min.css">
 		<script src="static_graph.js"></script>
 </div><!-- /page -->
 </body>

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/2-lines-rectangle-horizontal.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/2-lines-rectangle-horizontal.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/2-lines.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/2-lines.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/index.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/indicator.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/indicator.html
@@ -25,7 +25,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/simple.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/simple.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/vertical-2-lines-rectangle.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/vertical-2-lines-rectangle.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/vertical-2-lines.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/vertical-2-lines.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/vertical-simple.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/grid/vertical-simple.html
@@ -9,7 +9,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-medium.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-medium.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-small.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-small.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-with-subtitle-medium.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-with-subtitle-medium.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-with-subtitle-small.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-with-subtitle-small.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-with-subtitle.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title-with-subtitle.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/header/title.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/interactive/coverflow/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/interactive/coverflow/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<link rel="stylesheet" href="../../../lib/tau/wearable/theme/default/tau.css">
-	<script type="text/javascript" src="../../../lib/tau/wearable/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../../lib/tau/wearable/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 <div class="ui-page" id="demo-page">

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/interactive/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/interactive/index.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<script type="text/javascript" src="../../lib/tau/wearable/js/tau.js" data-build-remove="false"></script>
+	<script type="text/javascript" src="../../lib/tau/wearable/js/tau.bundle.js" data-build-remove="false"></script>
 </head>
 <body>
 <div class="ui-page" id="demo-page">

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/interactive/interactive3D/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/interactive/interactive3D/index.html
@@ -31,7 +31,7 @@
 	</div>
 </div>
 </body>
-<script src="../../../lib/tau/wearable/js/tau.js"></script>
+<script src="../../../lib/tau/wearable/js/tau.bundle.js"></script>
 <script src="../../../js/circle-helper.js"></script>
 <script src="../../../js/app.js"></script>
 <script src="../../../js/lowBatteryCheck.js"></script>

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclist_marquee_style.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclist_marquee_style.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/list_arclistview-2.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/list_arclistview-2.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/list_arclistview.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/list_arclistview.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/list_snaplistview.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/arclistview/list_snaplistview.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_5.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_5.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_buttons.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_buttons.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_divide.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_divide.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_divider.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_divider.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_input.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_input.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_marquee_style.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_marquee_style.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_multiline.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_multiline.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_normal.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_normal.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_selectmode.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_selectmode.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_swipelist.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/list_swipelist.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/snaplistview.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/snaplistview.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/snaplistview_no_header.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/snaplistview_no_header.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/list_subtext_1line.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/list_subtext_1line.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/list_subtext_2line.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/list_subtext_2line.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/list_subtext_3line.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/subtext/list_subtext_3line.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/list_thumbnail_1line.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/list_thumbnail_1line.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/list_thumbnail_2line.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/list_thumbnail_2line.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/list_thumbnail_3line.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/thumbnail/list_thumbnail_3line.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/1line_btn.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/1line_btn.html
@@ -9,7 +9,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/1line_icon.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/1line_icon.html
@@ -9,7 +9,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/3lines.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/3lines.html
@@ -9,7 +9,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/normal.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/normal.html
@@ -9,7 +9,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/snap.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/list/virtual/snap.html
@@ -9,7 +9,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/moreoptions/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/moreoptions/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/indexscrollbar/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/indexscrollbar/index.html
@@ -13,7 +13,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/add.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/add.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/bouncing.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/bouncing.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/circular.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/circular.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/hsection.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/hsection.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/index.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/nested.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/nested.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/scrollbar.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/scrollbar.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/tab.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/tab.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/vsection.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/navcontrols/sectionchanger/vsection.html
@@ -12,7 +12,7 @@
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>
-	<script src="../../../lib/tau/wearable/js/tau.js">
+	<script src="../../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/popup/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/popup/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/popup/popup.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/popup/popup.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/popup/popup_toast.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/popup/popup_toast.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/contents/rotaryevent/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/contents/rotaryevent/index.html
@@ -12,7 +12,7 @@
 	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../js/circle-helper.js">
 	</script>
-	<script src="../../lib/tau/wearable/js/tau.js">
+	<script src="../../lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 

--- a/sample/web/TAU_1.1_UIComponents_Wearable/index.html
+++ b/sample/web/TAU_1.1_UIComponents_Wearable/index.html
@@ -12,7 +12,7 @@
 	<link href="css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="js/circle-helper.js">
 	</script>
-	<script src="lib/tau/wearable/js/tau.js">
+	<script src="lib/tau/wearable/js/tau.bundle.js">
 	</script>
 </head>
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/197
[Problem] Design Editor currently does not support
          loading external resources on fly
[Solution] Use bundled tau version.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>