### PR TITLE
WATT 0.7.0 Release

### DIFF
--- a/libs/brackets-server/embedded-ext/about/htmlContent/about-watt-dialog.html
+++ b/libs/brackets-server/embedded-ext/about/htmlContent/about-watt-dialog.html
@@ -13,7 +13,7 @@
                   {{/BUILD_TIMESTAMP}}
                 </p>
 
-                <p class="dialog-message"><!-- $NON-NLS$ -->Copyright 2017 Samsung Electronics Incorporated and its licensors. All rights reserved.</p>
+                <p class="dialog-message"><!-- $NON-NLS$ -->Copyright 2017-2019 Samsung Electronics Incorporated and its licensors. All rights reserved.</p>
                 <p class="dialog-message">{{{Strings.ABOUT_TEXT_LINE2}}}</p>
                 <p class="dialog-message">{{{Strings.ABOUT_TEXT_LINE3}}}</p>
             </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watt",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "start": "node ./app.js",


### PR DESCRIPTION
[Problem] https://code.tizen.org has out dated (0.6.0) release version
[Solution] Update relese version. In addition, update copyright year in
           About WATT dialog window.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>