### PR TITLE
[Docker] Upgrade Ubuntu to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # $ sudo docker run -it simple bash
 
 # Download base image ubuntu 16.04 since most developers are using it.
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ################################ AS ROOT ################################
 


### PR DESCRIPTION
[Problem] According to [1], April 2021 is end of support
[Solution] Upgrade Ubuntu to 18.04
[Test] ./docker-run --rebuild
	   docker ps (find contaitner id for watt)
	   docker container exec -i CONTAINERID lsb_release -a
	   You should see the following output:
	   Description:	Ubuntu 18.04.3 LTS

[1] https://wiki.ubuntu.com/Releases

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>