### PR TITLE
Projects: Added includes feature to append files during the project creation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "1.0"]
 	path = TAU/1.0
 	url = https://github.com/Samsung/TAU.git
+[submodule "TAU/1.1"]
+	path = TAU/1.1
+	url = https://github.com/Samsung/TAU.git

--- a/sample/list.json
+++ b/sample/list.json
@@ -175,7 +175,11 @@
     "icon": "icon.png",
     "type": "web",
     "profile": "mobile,tv",
-    "category": "General"
+    "category": "General",
+    "includes": [{
+      "src": "TAU/1.1/dist",
+      "dest": "lib/tau"
+    }]
   },
   {
     "name": "TAU UI Components",
@@ -184,7 +188,11 @@
     "icon": "icon.png",
     "type": "web",
     "profile": "mobile,tv",
-    "category": "General"
+    "category": "General",
+    "includes": [{
+      "src": "TAU/1.1/dist",
+      "dest": "lib/tau"
+    }]
   },
   {
     "name": "TAU Base",
@@ -193,7 +201,11 @@
     "icon": "icon.png",
     "type": "web",
     "profile": "wearable",
-    "category": "General"
+    "category": "General",
+    "includes": [{
+      "src": "TAU/1.1/dist",
+      "dest": "lib/tau"
+    }]
   },
   {
     "name": "TAU UI Components",
@@ -202,6 +214,10 @@
     "icon": "icon.png",
     "type": "web",
     "profile": "wearable",
-    "category": "General"
+    "category": "General",
+    "includes": [{
+      "src": "TAU/1.1/dist",
+      "dest": "lib/tau"
+    }]
   }
 ]


### PR DESCRIPTION
Issue: related to https://github.com/Samsung/WATT/issues/169
Problem: Templates are using common files eg. TAU libraries.
 Update these modules requires too many actions.
Solution: Developer of DesignEditor can define files to includ in list.json
 by new keyword "includes".
 example:
```
"includes": [{
	"src": "TAU/dist",
        "dest": "lib/tau"
        }]
```

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>