### PR TITLE
Restore "Pack to WGT package" ctx menu for remote samples

### DIFF
--- a/libs/brackets-server/embedded-ext/project/main.js
+++ b/libs/brackets-server/embedded-ext/project/main.js
@@ -1321,7 +1321,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(PROJECT_PACK_WGT);
     } else if (type === "crx") {
         menu.addMenuItem(PROJECT_PACK_CRX);
-    } else if (type === "web" || type === "sthings") {
+    } else if (type === "web" || type === "sthings" || type === "demo") {
         menu.addMenuItem(PROJECT_PACK_WGT);
 
         if (PreferencesManager.getViewState("projectExtension") === "unity") {

--- a/libs/brackets-server/embedded-ext/tizen-profile/main.js
+++ b/libs/brackets-server/embedded-ext/tizen-profile/main.js
@@ -5,8 +5,7 @@ define(function (require, exports, module) {
     const PreferencesManager = brackets.getModule("preferences/PreferencesManager");
     const projectType = PreferencesManager.getViewState("projectType");
 
-    const allowProjectType = ["sthings", "web", "wasm"];
-    // Return extension when project type is not equal to web or sthings
+    const allowProjectType = ["sthings", "web", "demo", "wasm"];
     if (allowProjectType.indexOf(projectType) === -1) {
         return;
     }


### PR DESCRIPTION
[Problem] Lack of "Pack to WGT package" and "User certificate"
          context menu options for remote samples.

[Solution] Add missing context menu options for "demo" project type.

[Test]
    1. ./docker-run.sh --rebuild
    2. Open http://localhost:3000/demos?path=1.0%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fnumberpicker%2Findex.html
    3. Chose "Profile" -> "User certificate" and create certificate.
    4. You should see "Certificate saved succesfully".
    5. Click OK.
    6. Chose "Project" -> "Pack to WGT package".
    7. You should see "Package has been successfully built".
    8. Click OK.
    9. On file tree, you should see "Tau Sample Demo.wgt".

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>