### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/launch
+++ b/launch
@@ -32,7 +32,7 @@ class Log:
     sys.stdout.flush()
 
 SERVICE = 'WATT'
-supported = ('trusty', 'xenial')
+supported = ('trusty', 'xenial', 'bionic')
 
 root_path = os.path.abspath(os.path.dirname(__file__))
 tool_path = os.path.join(root_path, 'tools')
@@ -198,16 +198,26 @@ def install_mongodb():
   elif (os_name == 'Ubuntu') and (os_dist in supported):
     Log.info('Install mongodb with "apt-get" (sudo privileges required)')
     cmds = ['sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80' \
-      + ' --recv 0C49F3730359A14518585931BC711F9BA15703C6', '', \
+      + ' --recv 9DA31620334BD75D9DCB49F368818C72E52529D4', '', \
       'sudo apt-get update', 'sudo apt-get install -y mongodb-org']
+    #Ubuntu 14.04
     if os_dist == 'trusty':
       cmds[1] = 'echo "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu' \
         + ' trusty/mongodb-org/3.4 multiverse"' \
         + ' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list'
-    else:
+    # Ubuntu 16.04
+    elif os_dist == 'xenial':
       cmds[1] = 'echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/' \
         + 'ubuntu xenial/mongodb-org/3.4 multiverse"' \
         + ' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list'
+    # Ubutnu 18.04
+    elif os_dist == 'bionic':
+      cmds[1] = 'echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu' \
+        + ' bionic/mongodb-org/4.0 multiverse"' \
+        + ' | sudo tee /etc/apt/sources.list.d/mongodb.list'
+    else:
+      Log.err('Not suported distribution for mongodb installation')
+      return False
   else:
     Log.err('Cannot install mongodb automatically in %s(%s)' \
       % (os_name, os_dist))


### PR DESCRIPTION
[Issue] https://github.com/Samsung/WATT/issues/174
[Problem] No support for Ubuntu 18.04
[Solution] Add 18.04 to supported list. Update GPK key for MongoDB
and add 18.04 specific MongoDb repo url.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>