### PR TITLE
Unify mongodb version usage and remove Ubuntu 14.04 support

### DIFF
--- a/launch
+++ b/launch
@@ -32,7 +32,7 @@ class Log:
     sys.stdout.flush()
 
 SERVICE = 'WATT'
-supported = ('trusty', 'xenial', 'bionic')
+supported = ('xenial', 'bionic')
 
 root_path = os.path.abspath(os.path.dirname(__file__))
 tool_path = os.path.join(root_path, 'tools')
@@ -43,7 +43,7 @@ if os_name == 'Linux':
     os_name = subprocess.check_output(['lsb_release', '-i']).strip().split('\t')[1]
     os_dist = subprocess.check_output(['lsb_release', '-c']).strip().split('\t')[1]
   except subprocess.CalledProcessError:
-    Log.err('Unsupport os')
+    Log.err('Unsupported os')
     sys.exit(1)
 
 if os_name != 'Ubuntu' and os_name != 'Darwin':
@@ -197,24 +197,18 @@ def install_mongodb():
     cmds = ['brew update', 'brew install mongodb']
   elif (os_name == 'Ubuntu') and (os_dist in supported):
     Log.info('Install mongodb with "apt-get" (sudo privileges required)')
-    cmds = ['sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80' \
-      + ' --recv 9DA31620334BD75D9DCB49F368818C72E52529D4', '', \
-      'sudo apt-get update', 'sudo apt-get install -y mongodb-org']
-    #Ubuntu 14.04
-    if os_dist == 'trusty':
-      cmds[1] = 'echo "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu' \
-        + ' trusty/mongodb-org/3.4 multiverse"' \
-        + ' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list'
-    # Ubuntu 16.04
-    elif os_dist == 'xenial':
+    cmds = ['wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -', '', \
+      'sudo apt-get update', 'sudo apt-get install -y mongodb-org', 'sudo systemctl unmask mongodb']
+   # Ubuntu 16.04
+    if os_dist == 'xenial':
       cmds[1] = 'echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/' \
-        + 'ubuntu xenial/mongodb-org/3.4 multiverse"' \
-        + ' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list'
+        + 'ubuntu xenial/mongodb-org/4.2 multiverse"' \
+        + ' | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list'
     # Ubutnu 18.04
     elif os_dist == 'bionic':
       cmds[1] = 'echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu' \
-        + ' bionic/mongodb-org/4.0 multiverse"' \
-        + ' | sudo tee /etc/apt/sources.list.d/mongodb.list'
+        + ' bionic/mongodb-org/4.2 multiverse"' \
+        + ' | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list'
     else:
       Log.err('Not suported distribution for mongodb installation')
       return False
@@ -783,7 +777,7 @@ def main():
       os.putenv('SUPPORT_IOT_JS', 'true')
       os.putenv('IOT_JS_ROOT', iotjs_path)
     else:
-      Log.err('Ubuntu 14.04 or 16.04 are recommended.')
+      Log.err('Ubuntu 16.04 or 18.04 are recommended.')
       sys.exit(1)
 
   if args.sthings:


### PR DESCRIPTION
[Issue] https://github.com/Samsung/WATT/issues/176
[Problem] Different MongoDB version used for different distributions
[Solution] Use MongoDB version for Ubuntu 16.04 and 18.04
For Ubuntu 14.04 no MongoDB packages so remove it from supported list.
Ubuntu 14.04 already has end of standard support according to the [1]

[1] https://wiki.ubuntu.com/Releases

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>