### PR TITLE
Fix "NameError: global name 'install_deb_package' is not defined"

### DIFF
--- a/launch
+++ b/launch
@@ -52,7 +52,7 @@ if os_name != 'Ubuntu' and os_name != 'Darwin':
 
 def import_additional():
   status = subprocess.call('which pip > /dev/null', shell=True)
-  if status != 0 and not install_deb_package('pip'):
+  if status != 0 and not install_deb_package('python-pip'):
     Log.err('Fail to install pip')
     sys.exit(1)
 
@@ -67,7 +67,6 @@ def import_additional():
         Log.err('Fail to install %s' % package)
       module = __import__(package)
     globals()[package] = module
-import_additional()
 
 def install_nodejs():
   if os_name == 'Darwin':
@@ -736,6 +735,8 @@ def main():
     if (subprocess.check_call('./update_submodules' + (' --verbose' if args.verbose else ''), shell=True)) != 0:
       Log.err('Fail to initialize or update submodules.')
       return 1
+
+  import_additional()
 
   ret, grunt_path = prepare_nodejs(args.npm, args.pwe)
   if not ret:


### PR DESCRIPTION
[Issue] N/A
[Problem] on clean Ubuntu 18.04, launch script reports error:
    NameError: global name 'install_deb_package' is not defined
[Cause] install_deb_package is not defined when import_additional
    function is called.
[Solution] Move import_additional to main.
[Test]
    1. Before applying the patch do:
        -sudo apt-get remove python-pip
    2. You should see:
        NameError: global name 'install_deb_package' is not defined
    3. Apply the patch.
    4. python-pip should be installed automatically and WATT should start.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>