### PR TITLE
[Docker] Bump mongod version to 4.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mongo_container:
-    image: "mongo:3.4.19"
+    image: "mongo:4.2"
     restart: always
 
   watt_container:


### PR DESCRIPTION
[Issue] https://github.com/Samsung/WATT/issues/176

[Problem] WATT running locally uses mongod in version 4.2 but
    WATT running in Docker environment uses 3.2.

[Solution] Bump mongod version to 4.2

[Test]
    1. Clean all docker images related to mongo, for example
        docker image rm mongo:3.2

    ./docker-run --rebuild

[Remarks] This image was alredy pushed to AWS in order to
    include it in the upcoming watt release on AWS. They are
    available at:
    https://ap-south-1.console.aws.amazon.com/ecr/repositories/mongo_docker_repository/?region=ap-south-1
    https://ap-south-1.console.aws.amazon.com/ecr/repositories/mongo_docker_repository/?region=ap-northeast-2

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>