### PR TITLE
[Docker] Simultaneous docker image push

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ docker container exec -i 12cf98736487 bash
  * [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html)
  * Build and push watt docker image to AWS repositories and finally restart all WATT instances by
 ```bash
-./watt-aws-instances-update.sh AWS_ACCOUNT_ID
+./watt-aws-instances-update.sh AWS_ACCOUNT_ID [--simultaneous-image-push]
 ```
  * If you need additional steeps, for example, updating mongod image or create new repository just follow [this guide.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html#use-ecr)
  * Images should be available at [repositories](https://ap-northeast-2.console.aws.amazon.com/ecr/repositories?region=ap-northeast-2#).


### PR DESCRIPTION
[Issue] N/A
[Problem] Pushing docker images to two AWS instances
          is time consuming
[Solution] Add --simultaneous-image-push to watt-aws-instances-update.sh
           in order to push docker images in background.
           Output from docker demon is cumulated which means that progress of
           layer's push is reported to the same of line from different images.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>