### PR TITLE
Add TAU/1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "TAU/1.1"]
 	path = TAU/1.1
 	url = https://github.com/Samsung/TAU.git
+[submodule "TAU/1.2"]
+	path = TAU/1.2
+	url = https://github.com/Samsung/TAU.git


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1177
[Problem] TAU 1.2 examples are not working
[Solution] Add TAU/1.2 as sumboule which points to latest
	TAU 1.2 release https://github.com/Samsung/TAU/releases/tag/v.1.2.4
[TEST]
1. Build and run WATT
	./launch --verbose --bypass_nacl_sdk --bypass_emscripten

2. Open samples in Browser
	http://localhost:3000/demos?path=1.2%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fpresentation-views%2Flist%2Fmain%2Findex.html
	http://localhost:3000/demos?path=1.2%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fappbar%2Fmore-option-list-max-width.html

3. Open UIComponets app in Browser
        http://localhost:3000/TAU/1.2/examples/mobile/UIComponents/ (Mobile)
        http://localhost:3000/TAU/1.2/examples/wearable/UIComponents/ (Wearable)


Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>